### PR TITLE
feat: Specify services and/or users/roles to grant publish permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allow\_publish\_aws\_services | Allow these AWS services to publish messages in the topic.  Not used when `policy` variable is specified | `list(string)` | `[]` | no |
-| allow\_publish\_iam\_arns | Allow these IAM users/roles to publish messages in the topic.  Not used when `policy` variable is specified | `list(string)` | `[]` | no |
+| allow\_publish\_aws\_services | Allow these AWS services to publish messages in the topic.  Overrides the `policy` variable | `list(string)` | `[]` | no |
+| allow\_publish\_iam\_arns | Allow these IAM users/roles to publish messages in the topic.  Overrides the `policy` variable | `list(string)` | `[]` | no |
 | application\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
 | application\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | application\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allow\_publish\_aws\_services | Allow these AWS services to publish messages in the topic.  Overrides the `policy` variable | `list(string)` | `[]` | no |
-| allow\_publish\_iam\_arns | Allow these IAM users/roles to publish messages in the topic.  Overrides the `policy` variable | `list(string)` | `[]` | no |
+| allow\_publish\_aws\_services | Allow these AWS services to publish messages in the topic.  Not used when `policy` is specified. | `list(string)` | `[]` | no |
+| allow\_publish\_iam\_arns | Allow these IAM users/roles to publish messages in the topic.  Not used when `policy` is specified. | `list(string)` | `[]` | no |
 | application\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
 | application\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | application\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -28,30 +28,42 @@ module "sns_topic" {
 * [Complete SNS topics](https://github.com/terraform-aws-modules/terraform-aws-sns/tree/master/examples/complete)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| application\_failure\_feedback\_role\_arn | IAM role for failure feedback | string | `"null"` | no |
-| application\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | string | `"null"` | no |
-| application\_success\_feedback\_sample\_rate | Percentage of success to sample | string | `"null"` | no |
-| create\_sns\_topic | Whether to create the SNS topic | bool | `"true"` | no |
-| delivery\_policy | The SNS delivery policy | string | `"null"` | no |
-| display\_name | The display name for the SNS topic | string | `"null"` | no |
-| http\_failure\_feedback\_role\_arn | IAM role for failure feedback | string | `"null"` | no |
-| http\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | string | `"null"` | no |
-| http\_success\_feedback\_sample\_rate | Percentage of success to sample | string | `"null"` | no |
-| kms\_master\_key\_id | The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK | string | `"null"` | no |
-| lambda\_failure\_feedback\_role\_arn | IAM role for failure feedback | string | `"null"` | no |
-| lambda\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | string | `"null"` | no |
-| lambda\_success\_feedback\_sample\_rate | Percentage of success to sample | string | `"null"` | no |
-| name | The name of the SNS topic to create | string | `"null"` | no |
-| name\_prefix | The prefix name of the SNS topic to create | string | `"null"` | no |
-| policy | The fully-formed AWS policy as JSON | string | `"null"` | no |
-| sqs\_failure\_feedback\_role\_arn | IAM role for failure feedback | string | `"null"` | no |
-| sqs\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | string | `"null"` | no |
-| sqs\_success\_feedback\_sample\_rate | Percentage of success to sample | string | `"null"` | no |
-| tags | A mapping of tags to assign to all resources | map(string) | `{}` | no |
+|------|-------------|------|---------|:--------:|
+| allow\_publish\_aws\_services | Allow these AWS services to publish messages in the topic.  Not used when `policy` variable is specified | `list(string)` | `[]` | no |
+| allow\_publish\_iam\_arns | Allow these IAM users/roles to publish messages in the topic.  Not used when `policy` variable is specified | `list(string)` | `[]` | no |
+| application\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
+| application\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| application\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |
+| create\_sns\_topic | Whether to create the SNS topic | `bool` | `true` | no |
+| delivery\_policy | The SNS delivery policy | `string` | `null` | no |
+| display\_name | The display name for the SNS topic | `string` | `null` | no |
+| http\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
+| http\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| http\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |
+| kms\_master\_key\_id | The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK | `string` | `null` | no |
+| lambda\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
+| lambda\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| lambda\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |
+| name | The name of the SNS topic to create | `string` | `null` | no |
+| name\_prefix | The prefix name of the SNS topic to create | `string` | `null` | no |
+| policy | The fully-formed AWS policy as JSON | `string` | `null` | no |
+| sqs\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
+| sqs\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| sqs\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |
+| tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,28 @@
+resource "aws_sns_topic_policy" "this" {
+  arn    = aws_sns_topic.this.arn
+  policy = length(var.policy) > 0 ? var.policy : data.aws_iam_policy_document.this.json
+}
+
+data "aws_iam_policy_document" "this" {
+  statement {
+    effect    = "Allow"
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.this.arn]
+
+    principals {
+      type        = "Service"
+      identifiers = var.allow_publish_aws_services
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = var.allow_publish_iam_arns
+    }
+  }
+}
+
+
+
 resource "aws_sns_topic" "this" {
   count = var.create_sns_topic ? 1 : 0
 
@@ -5,7 +30,6 @@ resource "aws_sns_topic" "this" {
   name_prefix = var.name_prefix
 
   display_name                             = var.display_name
-  policy                                   = var.policy
   delivery_policy                          = var.delivery_policy
   application_success_feedback_role_arn    = var.application_success_feedback_role_arn
   application_success_feedback_sample_rate = var.application_success_feedback_sample_rate

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,15 @@
+variable "allow_publish_aws_services" {
+  type        = list(string)
+  description = "Allow these AWS services to publish messages in the topic.  Not used when `policy` variable is specified"
+  default     = []
+}
+
+variable "allow_publish_iam_arns" {
+  type        = list(string)
+  description = "Allow these IAM users/roles to publish messages in the topic.  Not used when `policy` variable is specified"
+  default     = []
+}
+
 variable "create_sns_topic" {
   description = "Whether to create the SNS topic"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "display_name" {
 variable "policy" {
   description = "The fully-formed AWS policy as JSON"
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "delivery_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,12 @@
 variable "allow_publish_aws_services" {
+  description = "Allow these AWS services to publish messages in the topic.  Overrides the `policy` variable"
   type        = list(string)
-  description = "Allow these AWS services to publish messages in the topic.  Not used when `policy` variable is specified"
   default     = []
 }
 
 variable "allow_publish_iam_arns" {
+  description = "Allow these IAM users/roles to publish messages in the topic.  Overrides the `policy` variable"
   type        = list(string)
-  description = "Allow these IAM users/roles to publish messages in the topic.  Not used when `policy` variable is specified"
   default     = []
 }
 
@@ -37,7 +37,7 @@ variable "display_name" {
 variable "policy" {
   description = "The fully-formed AWS policy as JSON"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "delivery_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 variable "allow_publish_aws_services" {
-  description = "Allow these AWS services to publish messages in the topic.  Overrides the `policy` variable"
+  description = "Allow these AWS services to publish messages in the topic.  Not used when `policy` is specified."
   type        = list(string)
   default     = []
 }
 
 variable "allow_publish_iam_arns" {
-  description = "Allow these IAM users/roles to publish messages in the topic.  Overrides the `policy` variable"
+  description = "Allow these IAM users/roles to publish messages in the topic.  Not used when `policy` is specified."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Description
This change will add an SNS topic policy granting publish permissions to the specified AWS services or IAM user/role ARNs (if at least one is specified).

## Motivation and Context
The change covers these very common use cases for SNS topics:
* An AWS service sends messages to an SNS topic for notifications
* A customer-hosted app sends messages to an SNS topic following the fanout pattern

## Breaking Changes
No breaking changes!  The `policy` variable always takes precedence so any current usage of the module will behave the same after merging this change.

## How Has This Been Tested?
Here are my test scenarios:
1. Provision a topic while specifying neither `policy`, `allow_publish_aws_services`, nor `allow_publish_iam_arns`
2. Provision a topic while specifying `policy`, `allow_publish_aws_services`, and `allow_publish_iam_arns`
3. Provision a topic while specifying `policy` but not `allow_publish_aws_services` and `allow_publish_iam_arns`
4. Provision a topic while specifying `allow_publish_aws_services` and `allow_publish_iam_arns` but not `policy`
5. Provision a topic while specifying `allow_publish_aws_services` but not `allow_publish_iam_arns` and `policy`
6. Provision a topic while specifying `allow_publish_iam_arns` but not `allow_publish_aws_services` and `policy`

My test environment is:
* MacOS Catalina 10.15.6
* Geniune AWS account
* janky little test config
```hcl
module test_topic {
  source = "../."
  name   = "TEMPORARYTESTTOPIC"
  # allow_publish_aws_services = ["cloudwatch.amazonaws.com"]
  # allow_publish_iam_arns     = ["arn:aws:iam::############:role/TESTROLE"]
  # policy = <<EOT
  # {
  #   "Version": "2012-10-17",
  #   "Statement": [
  #     {
  #       "Sid": "",
  #       "Effect": "Allow",
  #       "Principal": {
  #         "AWS": "arn:aws:iam::############:role/TESTROLE",
  #         "Service": "sqs.amazonaws.com"
  #       },
  #       "Action": "sns:Publish",
  #       "Resource": "*"
  #     }
  #   ]
  # }
  # EOT
}
```