### PR TITLE
feat: Specify users/roles to grant subscribe permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,30 +28,41 @@ module "sns_topic" {
 * [Complete SNS topics](https://github.com/terraform-aws-modules/terraform-aws-sns/tree/master/examples/complete)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| application\_failure\_feedback\_role\_arn | IAM role for failure feedback | string | `"null"` | no |
-| application\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | string | `"null"` | no |
-| application\_success\_feedback\_sample\_rate | Percentage of success to sample | string | `"null"` | no |
-| create\_sns\_topic | Whether to create the SNS topic | bool | `"true"` | no |
-| delivery\_policy | The SNS delivery policy | string | `"null"` | no |
-| display\_name | The display name for the SNS topic | string | `"null"` | no |
-| http\_failure\_feedback\_role\_arn | IAM role for failure feedback | string | `"null"` | no |
-| http\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | string | `"null"` | no |
-| http\_success\_feedback\_sample\_rate | Percentage of success to sample | string | `"null"` | no |
-| kms\_master\_key\_id | The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK | string | `"null"` | no |
-| lambda\_failure\_feedback\_role\_arn | IAM role for failure feedback | string | `"null"` | no |
-| lambda\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | string | `"null"` | no |
-| lambda\_success\_feedback\_sample\_rate | Percentage of success to sample | string | `"null"` | no |
-| name | The name of the SNS topic to create | string | `"null"` | no |
-| name\_prefix | The prefix name of the SNS topic to create | string | `"null"` | no |
-| policy | The fully-formed AWS policy as JSON | string | `"null"` | no |
-| sqs\_failure\_feedback\_role\_arn | IAM role for failure feedback | string | `"null"` | no |
-| sqs\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | string | `"null"` | no |
-| sqs\_success\_feedback\_sample\_rate | Percentage of success to sample | string | `"null"` | no |
-| tags | A mapping of tags to assign to all resources | map(string) | `{}` | no |
+|------|-------------|------|---------|:--------:|
+| allow\_subscribe\_iam\_arns | Allow these IAM users/roles to subscribe to the topic.  Not used when `policy` is specified. | `list(string)` | `[]` | no |
+| application\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
+| application\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| application\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |
+| create\_sns\_topic | Whether to create the SNS topic | `bool` | `true` | no |
+| delivery\_policy | The SNS delivery policy | `string` | `null` | no |
+| display\_name | The display name for the SNS topic | `string` | `null` | no |
+| http\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
+| http\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| http\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |
+| kms\_master\_key\_id | The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK | `string` | `null` | no |
+| lambda\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
+| lambda\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| lambda\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |
+| name | The name of the SNS topic to create | `string` | `null` | no |
+| name\_prefix | The prefix name of the SNS topic to create | `string` | `null` | no |
+| policy | The fully-formed AWS policy as JSON | `string` | `null` | no |
+| sqs\_failure\_feedback\_role\_arn | IAM role for failure feedback | `string` | `null` | no |
+| sqs\_success\_feedback\_role\_arn | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| sqs\_success\_feedback\_sample\_rate | Percentage of success to sample | `string` | `null` | no |
+| tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "allow_subscribe_iam_arns" {
+  description = "Allow these IAM users/roles to subscribe to the topic.  Not used when `policy` is specified."
+  type        = list(string)
+  default     = []
+}
+
 variable "create_sns_topic" {
   description = "Whether to create the SNS topic"
   type        = bool


### PR DESCRIPTION
## Description
This change will add an SNS topic policy granting subscribe permissions to the specified IAM user/role ARNs (if at least one is specified).

## Motivation and Context
The change covers a common use cases for SNS topics:
* Cross-account subscription support
* Enhanced pub/sub security needs

## Breaking Changes
No breaking changes! The policy variable always takes precedence so any current usage of the module will behave the same after merging this change.

## How Has This Been Tested?
Here are my test scenarios:

1. Provision a topic while specifying neither policy, nor allow_subscribe_iam_arns
2. Provision a topic while specifying policy and allow_subscribe_iam_arns
3. Provision a topic while specifying policy but not allow_subscribe_iam_arns
4. Provision a topic while specifying allow_subscribe_iam_arns but not policy

My test environment is:

- MacOS Catalina 10.15.6
- Geniune AWS account
- janky little test config

```hcl
module test_topic {
  source = "../."
  name   = "TEMPORARYTESTTOPIC"
  allow_subscribe_iam_arns = ["arn:aws:iam::XXXXXXXXXXXX:root"]
  policy                   = <<EOT
  {
    "Version": "2012-10-17",
    "Statement": [
      {
        "Sid": "",
        "Effect": "Allow",
        "Principal": {
          "AWS": "arn:aws:iam::XXXXXXXXXXXX:role/TESTROLE",
          "Service": "sqs.amazonaws.com"
        },
        "Action": "sns:Publish",
        "Resource": "*"
      }
    ]
  }
  EOT
```
