### PR TITLE
fix: update min terrafom version to allow static checks to pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module "sns_topic" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.64 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.64 |
 
 ## Providers

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
- update min terrafom version to allow static checks to pass

## Motivation and Context
- get static checks back into healthy state

## Breaking Changes
- no

## How Has This Been Tested?
- version change only, ci-cd should pass
