### PR TITLE
feat: Added content-based deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="v3.1.1"></a>
+## [v3.1.1] - 2021-09-15
 
+- feat: Enables content-based deduplication for FIFO topics. For more information, see the [related documentation](https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html)
 
 <a name="v3.1.0"></a>
 ## [v3.1.0] - 2021-06-03
@@ -75,7 +78,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-sns/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-sns/compare/v3.1.1...HEAD
+[v3.1.1]: https://github.com/terraform-aws-modules/terraform-aws-sns/compare/v3.1.0...v3.1.1
 [v3.1.0]: https://github.com/terraform-aws-modules/terraform-aws-sns/compare/v3.0.0...v3.1.0
 [v3.0.0]: https://github.com/terraform-aws-modules/terraform-aws-sns/compare/v2.3.0...v3.0.0
 [v2.3.0]: https://github.com/terraform-aws-modules/terraform-aws-sns/compare/v2.2.0...v2.3.0

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ No modules.
 | <a name="input_application_failure_feedback_role_arn"></a> [application\_failure\_feedback\_role\_arn](#input\_application\_failure\_feedback\_role\_arn) | IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_application_success_feedback_role_arn"></a> [application\_success\_feedback\_role\_arn](#input\_application\_success\_feedback\_role\_arn) | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | <a name="input_application_success_feedback_sample_rate"></a> [application\_success\_feedback\_sample\_rate](#input\_application\_success\_feedback\_sample\_rate) | Percentage of success to sample | `string` | `null` | no |
+| <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Boolean indicating whether or not to enable content-based deduplication for FIFO topics. | `bool` | `false` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create the SNS topic | `bool` | `true` | no |
 | <a name="input_delivery_policy"></a> [delivery\_policy](#input\_delivery\_policy) | The SNS delivery policy | `string` | `null` | no |
 | <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The display name for the SNS topic | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_sns_topic" "this" {
   sqs_failure_feedback_role_arn            = var.sqs_failure_feedback_role_arn
   kms_master_key_id                        = var.kms_master_key_id
   fifo_topic                               = var.fifo_topic
-  content_based_deduplication              = var.fifo_topic && var.content_based_deduplication ? true : false
+  content_based_deduplication              = var.content_based_deduplication
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "aws_sns_topic" "this" {
   sqs_failure_feedback_role_arn            = var.sqs_failure_feedback_role_arn
   kms_master_key_id                        = var.kms_master_key_id
   fifo_topic                               = var.fifo_topic
+  content_based_deduplication              = var.fifo_topic && var.content_based_deduplication ? true : false
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -123,3 +123,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "content_based_deduplication" {
+  description = "Boolean indicating whether or not to enable content-based deduplication for FIFO topics."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description
This minor change enables content-based deduplication for FIFO topics. For more information, see the [related documentation](https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html)

## Motivation and Context
There are some use cases when SNS topic requires content-based deduplication and at the moment this module doesn't support it.

## Breaking Changes
No breaking changes, if/else logic implemented to enable content-based deduplication only if FIFO SNS is enabled.

## How Has This Been Tested?
Tested by duplicating this module locally and adding `content_based_deduplication` argument.
