### PR TITLE
feat: Added outputs sns_topic_name, sns_topic_id, sns_topic_owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | ARN of SNS topic |
+| <a name="output_sns_topic_name"></a> [sns\_topic\_name](#output\_sns\_topic\_name) | NAME of SNS topic |
+| <a name="output_sns_topic_id"></a> [sns\_topic\_id](#output\_sns\_topic\_id) | ID of SNS topic |
+| <a name="output_sns_topic_owner"></a> [sns\_topic\_owner](#output\_sns\_topic\_owner) | OWNER of SNS topic |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | ARN of SNS topic |
-| <a name="output_sns_topic_name"></a> [sns\_topic\_name](#output\_sns\_topic\_name) | NAME of SNS topic |
 | <a name="output_sns_topic_id"></a> [sns\_topic\_id](#output\_sns\_topic\_id) | ID of SNS topic |
+| <a name="output_sns_topic_name"></a> [sns\_topic\_name](#output\_sns\_topic\_name) | NAME of SNS topic |
 | <a name="output_sns_topic_owner"></a> [sns\_topic\_owner](#output\_sns\_topic\_owner) | OWNER of SNS topic |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,16 +4,16 @@ output "sns_topic_arn" {
 }
 
 output "sns_topic_name" {
-  description = "name of SNS topic"
+  description = "NAME of SNS topic"
   value       = element(concat(aws_sns_topic.this.*.name, [""]), 0)
 }
 
 output "sns_topic_id" {
-  description = "id of SNS topic"
+  description = "ID of SNS topic"
   value       = element(concat(aws_sns_topic.this.*.id, [""]), 0)
 }
 
 output "sns_topic_owner" {
-  description = "owner of SNS topic"
+  description = "OWNER of SNS topic"
   value       = element(concat(aws_sns_topic.this.*.owner, [""]), 0)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,18 @@ output "sns_topic_arn" {
   description = "ARN of SNS topic"
   value       = element(concat(aws_sns_topic.this.*.arn, [""]), 0)
 }
+
+output "sns_topic_name" {
+  description = "name of SNS topic"
+  value       = element(concat(aws_sns_topic.this.*.name, [""]), 0)
+}
+
+output "sns_topic_id" {
+  description = "name of SNS topic"
+  value       = element(concat(aws_sns_topic.this.*.id, [""]), 0)
+}
+
+output "sns_topic_owner" {
+  description = "name of SNS topic"
+  value       = element(concat(aws_sns_topic.this.*.owner, [""]), 0)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,11 +9,11 @@ output "sns_topic_name" {
 }
 
 output "sns_topic_id" {
-  description = "name of SNS topic"
+  description = "id of SNS topic"
   value       = element(concat(aws_sns_topic.this.*.id, [""]), 0)
 }
 
 output "sns_topic_owner" {
-  description = "name of SNS topic"
+  description = "owner of SNS topic"
   value       = element(concat(aws_sns_topic.this.*.owner, [""]), 0)
 }


### PR DESCRIPTION
## Description
This change will add outputs to the module to allow for greater integration with terraform modules and resources

## Motivation and Context
The change covers common use cases for SNS topics:

- Implementation on resources and modules
- Get more details on running the Terrafom Plan / Apply command

## Breaking Changes
No breaking changes!

## How Has This Been Tested?
Here are my test scenarios:
Created a Topic SNS and sent the following values in outputs:
- sns_topic_name

- sns_topic_arn

- sns_topic_id

- sns_topic_owner

After executing the Terraform Apply command, the correct execution was verified.

The code used to run the test is located at this repository: [simoferr98/infrastructure-terraform-example](https://github.com/simoferr98/infrastructure-terraform-example/tree/develop)

My test environment is:
- MacOS Monterey 12.0.1
- Terraform v1.0.11
- AWS Personal Account