### PR TITLE
feat: Add support for Terraform resource (aws_sns_topic_subscription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,38 @@ Terraform module which creates SNS resources on AWS
 
 ## Usage
 
+**Create the SNS topic:**
+
 ```hcl
 module "sns_topic" {
   source  = "terraform-aws-modules/sns/aws"
   version = "~> 3.0"
 
   name  = "my-topic"
+}
+```
+
+**Create the SNS topic subscription:**
+
+```hcl
+module "sqs_queue" {
+  source  = "terraform-aws-modules/sqs/aws"
+  version = "~> 3.0"
+
+  name = "my-queue"
+}
+
+module "sns_topic" {
+  source  = "terraform-aws-modules/sns/aws"
+  version = "~> 3.0"
+
+  name = "my-topic"
+
+  create_sns_topic_subscription = true
+  endpoint             = module.sqs_queue.sqs_queue_arn
+  protocol             = "sqs"
+  topic_arn            = module.sns_topic.sns_topic_arn
+  raw_message_delivery = true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Terraform module which creates SNS resources on AWS
 
 ## Usage
 
-**Create the SNS topic:**
-
 ```hcl
 module "sns_topic" {
   source  = "terraform-aws-modules/sns/aws"
@@ -15,33 +13,10 @@ module "sns_topic" {
 }
 ```
 
-**Create the SNS topic subscription:**
-
-```hcl
-module "sqs_queue" {
-  source  = "terraform-aws-modules/sqs/aws"
-  version = "~> 3.0"
-
-  name = "my-queue"
-}
-
-module "sns_topic" {
-  source  = "terraform-aws-modules/sns/aws"
-  version = "~> 3.0"
-
-  name = "my-topic"
-
-  create_sns_topic_subscription = true
-  endpoint             = module.sqs_queue.sqs_queue_arn
-  protocol             = "sqs"
-  topic_arn            = module.sns_topic.sns_topic_arn
-  raw_message_delivery = true
-}
-```
-
 ## Examples
 
 - [Complete SNS topics](https://github.com/terraform-aws-modules/terraform-aws-sns/tree/master/examples/complete)
+- [Subscribe SNS topic to SQS queue](https://github.com/terraform-aws-modules/terraform-aws-sns/tree/master/examples/subscribe_sns_to_sqs)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -66,6 +41,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 
 ## Inputs
 
@@ -74,11 +50,16 @@ No modules.
 | <a name="input_application_failure_feedback_role_arn"></a> [application\_failure\_feedback\_role\_arn](#input\_application\_failure\_feedback\_role\_arn) | IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_application_success_feedback_role_arn"></a> [application\_success\_feedback\_role\_arn](#input\_application\_success\_feedback\_role\_arn) | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | <a name="input_application_success_feedback_sample_rate"></a> [application\_success\_feedback\_sample\_rate](#input\_application\_success\_feedback\_sample\_rate) | Percentage of success to sample | `string` | `null` | no |
+| <a name="input_confirmation_timeout_in_minutes"></a> [confirmation\_timeout\_in\_minutes](#input\_confirmation\_timeout\_in\_minutes) | Integer indicating number of minutes to wait in retrying mode for fetching subscription arn before marking it as failure | `number` | `1` | no |
 | <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Boolean indicating whether or not to enable content-based deduplication for FIFO topics. | `bool` | `false` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create the SNS topic | `bool` | `true` | no |
+| <a name="input_create_sns_topic_subscription"></a> [create\_sns\_topic\_subscription](#input\_create\_sns\_topic\_subscription) | Whether to create the SNS topic subscription | `bool` | `false` | no |
 | <a name="input_delivery_policy"></a> [delivery\_policy](#input\_delivery\_policy) | The SNS delivery policy | `string` | `null` | no |
 | <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The display name for the SNS topic | `string` | `null` | no |
+| <a name="input_endpoint"></a> [endpoint](#input\_endpoint) | Endpoint to send data to | `string` | `null` | no |
+| <a name="input_endpoint_auto_confirms"></a> [endpoint\_auto\_confirms](#input\_endpoint\_auto\_confirms) | Whether the endpoint is capable of auto confirming subscription | `bool` | `false` | no |
 | <a name="input_fifo_topic"></a> [fifo\_topic](#input\_fifo\_topic) | Boolean indicating whether or not to create a FIFO (first-in-first-out) topic | `bool` | `false` | no |
+| <a name="input_filter_policy"></a> [filter\_policy](#input\_filter\_policy) | JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource | `string` | `null` | no |
 | <a name="input_http_failure_feedback_role_arn"></a> [http\_failure\_feedback\_role\_arn](#input\_http\_failure\_feedback\_role\_arn) | IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_http_success_feedback_role_arn"></a> [http\_success\_feedback\_role\_arn](#input\_http\_success\_feedback\_role\_arn) | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | <a name="input_http_success_feedback_sample_rate"></a> [http\_success\_feedback\_sample\_rate](#input\_http\_success\_feedback\_sample\_rate) | Percentage of success to sample | `string` | `null` | no |
@@ -89,10 +70,14 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name of the SNS topic to create | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The prefix name of the SNS topic to create | `string` | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | The fully-formed AWS policy as JSON | `string` | `null` | no |
+| <a name="input_protocol"></a> [protocol](#input\_protocol) | Protocol to use | `string` | `null` | no |
+| <a name="input_raw_message_delivery"></a> [raw\_message\_delivery](#input\_raw\_message\_delivery) | Whether to enable raw message delivery | `bool` | `false` | no |
+| <a name="input_redrive_policy"></a> [redrive\_policy](#input\_redrive\_policy) | JSON String with the redrive policy that will be used in the subscription | `string` | `null` | no |
 | <a name="input_sqs_failure_feedback_role_arn"></a> [sqs\_failure\_feedback\_role\_arn](#input\_sqs\_failure\_feedback\_role\_arn) | IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_sqs_success_feedback_role_arn"></a> [sqs\_success\_feedback\_role\_arn](#input\_sqs\_success\_feedback\_role\_arn) | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | <a name="input_sqs_success_feedback_sample_rate"></a> [sqs\_success\_feedback\_sample\_rate](#input\_sqs\_success\_feedback\_sample\_rate) | Percentage of success to sample | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
+| <a name="input_topic_arn"></a> [topic\_arn](#input\_topic\_arn) | ARN of the SNS topic to subscribe to | `string` | `null` | no |
 
 ## Outputs
 
@@ -102,6 +87,11 @@ No modules.
 | <a name="output_sns_topic_id"></a> [sns\_topic\_id](#output\_sns\_topic\_id) | ID of SNS topic |
 | <a name="output_sns_topic_name"></a> [sns\_topic\_name](#output\_sns\_topic\_name) | NAME of SNS topic |
 | <a name="output_sns_topic_owner"></a> [sns\_topic\_owner](#output\_sns\_topic\_owner) | OWNER of SNS topic |
+| <a name="output_sns_topic_subscription_arn"></a> [sns\_topic\_subscription\_arn](#output\_sns\_topic\_subscription\_arn) | ARN of the subscription |
+| <a name="output_sns_topic_subscription_confirmation_was_authenticated"></a> [sns\_topic\_subscription\_confirmation\_was\_authenticated](#output\_sns\_topic\_subscription\_confirmation\_was\_authenticated) | Whether the subscription confirmation request was authenticated |
+| <a name="output_sns_topic_subscription_id"></a> [sns\_topic\_subscription\_id](#output\_sns\_topic\_subscription\_id) | ID of the subscription |
+| <a name="output_sns_topic_subscription_owner_id"></a> [sns\_topic\_subscription\_owner\_id](#output\_sns\_topic\_subscription\_owner\_id) | AWS account ID of the subscription's owner |
+| <a name="output_sns_topic_subscription_pending_confirmation"></a> [sns\_topic\_subscription\_pending\_confirmation](#output\_sns\_topic\_subscription\_pending\_confirmation) | Whether the subscription has not been confirmed |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/subscribe_sns_to_sqs/README.md
+++ b/examples/subscribe_sns_to_sqs/README.md
@@ -1,0 +1,60 @@
+# Subscribe SNS topic to SQS queue
+
+Configuration in this directory will subscribe an SNS topic to an SQS queue.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.37 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_sns_topic"></a> [sns\_topic](#module\_sns\_topic) | ../../ | n/a |
+| <a name="module_sqs_queue"></a> [sqs\_queue](#module\_sqs\_queue) | terraform-aws-modules/sqs/aws | ~> 3.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | ARN of SNS topic |
+| <a name="output_sns_topic_id"></a> [sns\_topic\_id](#output\_sns\_topic\_id) | ID of SNS topic |
+| <a name="output_sns_topic_name"></a> [sns\_topic\_name](#output\_sns\_topic\_name) | NAME of SNS topic |
+| <a name="output_sns_topic_owner"></a> [sns\_topic\_owner](#output\_sns\_topic\_owner) | OWNER of SNS topic |
+| <a name="output_sns_topic_subscription_arn"></a> [sns\_topic\_subscription\_arn](#output\_sns\_topic\_subscription\_arn) | ARN of the subscription |
+| <a name="output_sns_topic_subscription_confirmation_was_authenticated"></a> [sns\_topic\_subscription\_confirmation\_was\_authenticated](#output\_sns\_topic\_subscription\_confirmation\_was\_authenticated) | Whether the subscription confirmation request was authenticated |
+| <a name="output_sns_topic_subscription_id"></a> [sns\_topic\_subscription\_id](#output\_sns\_topic\_subscription\_id) | ID of the subscription |
+| <a name="output_sns_topic_subscription_owner_id"></a> [sns\_topic\_subscription\_owner\_id](#output\_sns\_topic\_subscription\_owner\_id) | AWS account ID of the subscription's owner |
+| <a name="output_sns_topic_subscription_pending_confirmation"></a> [sns\_topic\_subscription\_pending\_confirmation](#output\_sns\_topic\_subscription\_pending\_confirmation) | Whether the subscription has not been confirmed |
+| <a name="output_sqs_queue_arn"></a> [sqs\_queue\_arn](#output\_sqs\_queue\_arn) | The ARN of the SQS queue |
+| <a name="output_sqs_queue_id"></a> [sqs\_queue\_id](#output\_sqs\_queue\_id) | The URL for the created Amazon SQS queue |
+| <a name="output_sqs_queue_name"></a> [sqs\_queue\_name](#output\_sqs\_queue\_name) | The name of the SQS queue |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/subscribe_sns_to_sqs/locals.tf
+++ b/examples/subscribe_sns_to_sqs/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  sqs_name = "my-queue"
+
+  sns_name                 = "my-topic"
+  sns_protocol             = "sqs"
+  sns_raw_message_delivery = true
+}

--- a/examples/subscribe_sns_to_sqs/main.tf
+++ b/examples/subscribe_sns_to_sqs/main.tf
@@ -1,0 +1,20 @@
+module "sqs_queue" {
+  source  = "terraform-aws-modules/sqs/aws"
+  version = "~> 3.0"
+
+  name = local.sqs_name
+}
+
+module "sns_topic" {
+  # source  = "terraform-aws-modules/sns/aws"
+  # version = "~> 3.0"
+  source = "../../"
+
+  name = local.sns_name
+
+  create_sns_topic_subscription = true
+  endpoint                      = module.sqs_queue.sqs_queue_arn
+  protocol                      = local.sns_protocol
+  topic_arn                     = module.sns_topic.sns_topic_arn
+  raw_message_delivery          = local.sns_raw_message_delivery
+}

--- a/examples/subscribe_sns_to_sqs/outputs.tf
+++ b/examples/subscribe_sns_to_sqs/outputs.tf
@@ -1,0 +1,59 @@
+output "sqs_queue_id" {
+  value       = module.sqs_queue.sqs_queue_id
+  description = "The URL for the created Amazon SQS queue"
+}
+
+output "sqs_queue_arn" {
+  value       = module.sqs_queue.sqs_queue_arn
+  description = "The ARN of the SQS queue"
+}
+
+output "sqs_queue_name" {
+  value       = module.sqs_queue.sqs_queue_name
+  description = "The name of the SQS queue"
+}
+
+output "sns_topic_arn" {
+  value       = module.sns_topic.sns_topic_arn
+  description = "ARN of SNS topic"
+}
+
+output "sns_topic_name" {
+  value       = module.sns_topic.sns_topic_name
+  description = "NAME of SNS topic"
+}
+
+output "sns_topic_id" {
+  value       = module.sns_topic.sns_topic_id
+  description = "ID of SNS topic"
+}
+
+output "sns_topic_owner" {
+  value       = module.sns_topic.sns_topic_owner
+  description = "OWNER of SNS topic"
+}
+
+output "sns_topic_subscription_arn" {
+  value       = module.sns_topic.sns_topic_subscription_arn
+  description = "ARN of the subscription"
+}
+
+output "sns_topic_subscription_confirmation_was_authenticated" {
+  value       = module.sns_topic.sns_topic_subscription_confirmation_was_authenticated
+  description = "Whether the subscription confirmation request was authenticated"
+}
+
+output "sns_topic_subscription_id" {
+  value       = module.sns_topic.sns_topic_subscription_id
+  description = "ID of the subscription"
+}
+
+output "sns_topic_subscription_owner_id" {
+  value       = module.sns_topic.sns_topic_subscription_owner_id
+  description = "AWS account ID of the subscription's owner"
+}
+
+output "sns_topic_subscription_pending_confirmation" {
+  value       = module.sns_topic.sns_topic_subscription_pending_confirmation
+  description = "Whether the subscription has not been confirmed"
+}

--- a/examples/subscribe_sns_to_sqs/providers.tf
+++ b/examples/subscribe_sns_to_sqs/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "eu-central-1"
+}

--- a/examples/subscribe_sns_to_sqs/versions.tf
+++ b/examples/subscribe_sns_to_sqs/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.37"
+    }
+  }
+
+  required_version = ">= 0.12"
+}

--- a/main.tf
+++ b/main.tf
@@ -25,3 +25,17 @@ resource "aws_sns_topic" "this" {
 
   tags = var.tags
 }
+
+resource "aws_sns_topic_subscription" "this" {
+  count = var.create_sns_topic_subscription ? 1 : 0
+
+  endpoint                        = var.endpoint
+  protocol                        = var.protocol
+  topic_arn                       = var.topic_arn
+  confirmation_timeout_in_minutes = var.confirmation_timeout_in_minutes
+  delivery_policy                 = var.delivery_policy
+  endpoint_auto_confirms          = var.endpoint_auto_confirms
+  filter_policy                   = var.filter_policy
+  raw_message_delivery            = var.raw_message_delivery
+  redrive_policy                  = var.redrive_policy
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,28 @@ output "sns_topic_owner" {
   description = "OWNER of SNS topic"
   value       = element(concat(aws_sns_topic.this.*.owner, [""]), 0)
 }
+
+output "sns_topic_subscription_arn" {
+  description = "ARN of the subscription"
+  value       = element(concat(aws_sns_topic_subscription.this.*.arn, [""]), 0)
+}
+
+output "sns_topic_subscription_confirmation_was_authenticated" {
+  description = "Whether the subscription confirmation request was authenticated"
+  value       = element(concat(aws_sns_topic_subscription.this.*.confirmation_was_authenticated, [""]), 0)
+}
+
+output "sns_topic_subscription_id" {
+  description = "ID of the subscription"
+  value       = element(concat(aws_sns_topic_subscription.this.*.id, [""]), 0)
+}
+
+output "sns_topic_subscription_owner_id" {
+  description = "AWS account ID of the subscription's owner"
+  value       = element(concat(aws_sns_topic_subscription.this.*.owner_id, [""]), 0)
+}
+
+output "sns_topic_subscription_pending_confirmation" {
+  description = "Whether the subscription has not been confirmed"
+  value       = element(concat(aws_sns_topic_subscription.this.*.pending_confirmation, [""]), 0)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,63 @@ variable "content_based_deduplication" {
   type        = bool
   default     = false
 }
+
+variable "create_sns_topic_subscription" {
+  description = "Whether to create the SNS topic subscription"
+  type        = bool
+  default     = false
+}
+
+variable "endpoint" {
+  description = "Endpoint to send data to"
+  type        = string
+  default     = null
+}
+
+variable "protocol" {
+  description = "Protocol to use"
+  type        = string
+  default     = null
+}
+
+variable "topic_arn" {
+  description = "ARN of the SNS topic to subscribe to"
+  type        = string
+  default     = null
+}
+
+variable "confirmation_timeout_in_minutes" {
+  description = "Integer indicating number of minutes to wait in retrying mode for fetching subscription arn before marking it as failure"
+  type        = number
+  default     = 1
+}
+
+# variable "delivery_policy" {
+#   description = "JSON String with the delivery policy (retries, backoff, etc.) that will be used in the subscription"
+#   type        = string
+#   default     = null
+# }
+
+variable "endpoint_auto_confirms" {
+  description = "Whether the endpoint is capable of auto confirming subscription"
+  type        = bool
+  default     = false
+}
+
+variable "filter_policy" {
+  description = "JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource"
+  type        = string
+  default     = null
+}
+
+variable "raw_message_delivery" {
+  description = "Whether to enable raw message delivery"
+  type        = bool
+  default     = false
+}
+
+variable "redrive_policy" {
+  description = "JSON String with the redrive policy that will be used in the subscription"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Description
This pull request will add support for the Terraform resource:
* aws_sns_topic_subscription

## Motivation and Context
This Terraform module should be able to manage SNS topic subscriptions.

## Breaking Changes
This change does not break anything, because this feature is disabled by default.

## How Has This Been Tested?
- [x] I have tested these changes using `terraform plan` and `terraform apply`, locally.
