### PR TITLE
feat: Add firehose args

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ No modules.
 | <a name="input_fifo_topic"></a> [fifo\_topic](#input\_fifo\_topic) | Boolean indicating whether or not to create a FIFO (first-in-first-out) topic | `bool` | `false` | no |
 | <a name="input_firehose_failure_feedback_role_arn"></a> [firehose\_failure\_feedback\_role\_arn](#input\_firehose\_failure\_feedback\_role\_arn) | IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_firehose_success_feedback_role_arn"></a> [firehose\_success\_feedback\_role\_arn](#input\_firehose\_success\_feedback\_role\_arn) | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
-| <a name="input_firehose_success_feedback_sample_rate"></a> [firehose\_success\_feedback\_sample\_rate](#input\_firehose\_success\_feedback\_sample\_rate) | Percentage of success to sample | `string` | `null` | no |
+| <a name="input_firehose_success_feedback_sample_rate"></a> [firehose\_success\_feedback\_sample\_rate](#input\_firehose\_success\_feedback\_sample\_rate) | Percentage of success to sample | `number` | `null` | no |
 | <a name="input_http_failure_feedback_role_arn"></a> [http\_failure\_feedback\_role\_arn](#input\_http\_failure\_feedback\_role\_arn) | IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_http_success_feedback_role_arn"></a> [http\_success\_feedback\_role\_arn](#input\_http\_success\_feedback\_role\_arn) | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | <a name="input_http_success_feedback_sample_rate"></a> [http\_success\_feedback\_sample\_rate](#input\_http\_success\_feedback\_sample\_rate) | Percentage of success to sample | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ No modules.
 | <a name="input_delivery_policy"></a> [delivery\_policy](#input\_delivery\_policy) | The SNS delivery policy | `string` | `null` | no |
 | <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The display name for the SNS topic | `string` | `null` | no |
 | <a name="input_fifo_topic"></a> [fifo\_topic](#input\_fifo\_topic) | Boolean indicating whether or not to create a FIFO (first-in-first-out) topic | `bool` | `false` | no |
+| <a name="input_firehose_failure_feedback_role_arn"></a> [firehose\_failure\_feedback\_role\_arn](#input\_firehose\_failure\_feedback\_role\_arn) | IAM role for failure feedback | `string` | `null` | no |
+| <a name="input_firehose_success_feedback_role_arn"></a> [firehose\_success\_feedback\_role\_arn](#input\_firehose\_success\_feedback\_role\_arn) | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| <a name="input_firehose_success_feedback_sample_rate"></a> [firehose\_success\_feedback\_sample\_rate](#input\_firehose\_success\_feedback\_sample\_rate) | Percentage of success to sample | `string` | `null` | no |
 | <a name="input_http_failure_feedback_role_arn"></a> [http\_failure\_feedback\_role\_arn](#input\_http\_failure\_feedback\_role\_arn) | IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_http_success_feedback_role_arn"></a> [http\_success\_feedback\_role\_arn](#input\_http\_success\_feedback\_role\_arn) | The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | <a name="input_http_success_feedback_sample_rate"></a> [http\_success\_feedback\_sample\_rate](#input\_http\_success\_feedback\_sample\_rate) | Percentage of success to sample | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,9 @@ resource "aws_sns_topic" "this" {
   application_success_feedback_role_arn    = var.application_success_feedback_role_arn
   application_success_feedback_sample_rate = var.application_success_feedback_sample_rate
   application_failure_feedback_role_arn    = var.application_failure_feedback_role_arn
+  firehose_success_feedback_role_arn       = var.firehose_success_feedback_role_arn
+  firehose_success_feedback_sample_rate    = var.firehose_success_feedback_sample_rate
+  firehose_failure_feedback_role_arn       = var.firehose_failure_feedback_role_arn
   http_success_feedback_role_arn           = var.http_success_feedback_role_arn
   http_success_feedback_sample_rate        = var.http_success_feedback_sample_rate
   http_failure_feedback_role_arn           = var.http_failure_feedback_role_arn

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,24 @@ variable "application_failure_feedback_role_arn" {
   default     = null
 }
 
+variable "firehose_success_feedback_role_arn" {
+  description = "The IAM role permitted to receive success feedback for this topic"
+  type        = string
+  default     = null
+}
+
+variable "firehose_success_feedback_sample_rate" {
+  description = "Percentage of success to sample"
+  type        = string
+  default     = null
+}
+
+variable "firehose_failure_feedback_role_arn" {
+  description = "IAM role for failure feedback"
+  type        = string
+  default     = null
+}
+
 variable "http_success_feedback_role_arn" {
   description = "The IAM role permitted to receive success feedback for this topic"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -60,7 +60,7 @@ variable "firehose_success_feedback_role_arn" {
 
 variable "firehose_success_feedback_sample_rate" {
   description = "Percentage of success to sample"
-  type        = string
+  type        = number
   default     = null
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add the AWS Firehose arguments to the SNS terraform module

Closes #34 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since the [terraform-aws-provider - v3.43.0](https://github.com/hashicorp/terraform-provider-aws/blob/v3.43.0/CHANGELOG.md) version, the support to AWS Firehose arguments was added

This PR adds these arguments to the SNS terraform module

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
