### PR TITLE
fix: Attach external topic policy when `create_topic_policy` is `false`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_sns_topic" "this" {
   lambda_success_feedback_role_arn    = try(var.lambda_feedback.success_role_arn, null)
   lambda_success_feedback_sample_rate = try(var.lambda_feedback.success_sample_rate, null)
 
-  policy = var.create_topic_policy ? var.topic_policy : null
+  policy = var.create_topic_policy ? null : var.topic_policy
 
   sqs_failure_feedback_role_arn    = try(var.sqs_feedback.failure_role_arn, null)
   sqs_success_feedback_role_arn    = try(var.sqs_feedback.success_role_arn, null)


### PR DESCRIPTION
## Description
Attach external policy OR create attachment by the module

## Motivation and Context
There is no way to attach externally created IAM policy without creating the internal one by the module itself

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have tested it on my own setup, because examples do not cover such case
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
