### PR TITLE
feat: Add data protection policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ module "sns_topic" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.56 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.62 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.56 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62 |
 
 ## Modules
 
@@ -152,6 +152,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_data_protection_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_data_protection_policy) | resource |
 | [aws_sns_topic_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
 | [aws_sns_topic_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -166,6 +167,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_subscription"></a> [create\_subscription](#input\_create\_subscription) | Determines whether an SNS subscription is created | `bool` | `true` | no |
 | <a name="input_create_topic_policy"></a> [create\_topic\_policy](#input\_create\_topic\_policy) | Determines whether an SNS topic policy is created | `bool` | `true` | no |
+| <a name="input_data_protection_policy"></a> [data\_protection\_policy](#input\_data\_protection\_policy) | A map of data protection policy statements | `string` | `null` | no |
 | <a name="input_delivery_policy"></a> [delivery\_policy](#input\_delivery\_policy) | The SNS delivery policy | `string` | `null` | no |
 | <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The display name for the SNS topic | `string` | `null` | no |
 | <a name="input_enable_default_topic_policy"></a> [enable\_default\_topic\_policy](#input\_enable\_default\_topic\_policy) | Specifies whether to enable the default topic policy. Defaults to `true` | `bool` | `true` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -27,11 +27,11 @@ module "default_sns" {
 
   data_protection_policy = jsonencode(
     {
-      Description = "Test"
-      Name        = "Test"
+      Description = "Deny Inbound Address"
+      Name        = "DenyInboundEmailAdressPolicy"
       Statement = [
         {
-          "DataDirection" = "Inbound"
+          "DataDirection" = "Outbound"
           "DataIdentifier" = [
             "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
           ]
@@ -41,7 +41,7 @@ module "default_sns" {
           "Principal" = [
             "*",
           ]
-          "Sid" = "Deny"
+          "Sid" = "DenyInboundEmailAddress"
         },
       ]
       Version = "2021-06-01"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -25,6 +25,29 @@ module "default_sns" {
   name              = "${local.name}-default"
   signature_version = 2
 
+  data_protection_policy = jsonencode(
+    {
+      Description = "Test"
+      Name        = "Test"
+      Statement = [
+        {
+          "DataDirection" = "Inbound"
+          "DataIdentifier" = [
+            "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+          ]
+          "Operation" = {
+            "Deny" = {}
+          }
+          "Principal" = [
+            "*",
+          ]
+          "Sid" = "Deny"
+        },
+      ]
+      Version = "2021-06-01"
+    }
+  )
+
   tags = local.tags
 }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -31,7 +31,7 @@ module "default_sns" {
       Name        = "DenyInboundEmailAdressPolicy"
       Statement = [
         {
-          "DataDirection" = "Outbound"
+          "DataDirection" = "Inbound"
           "DataIdentifier" = [
             "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
           ]

--- a/main.tf
+++ b/main.tf
@@ -154,3 +154,13 @@ resource "aws_sns_topic_subscription" "this" {
   subscription_role_arn           = try(each.value.subscription_role_arn, null)
   topic_arn                       = aws_sns_topic.this[0].arn
 }
+
+################################################################################
+# Data Protection Policy
+################################################################################
+
+resource "aws_sns_topic_data_protection_policy" "this" {
+  count  = var.create && var.data_protection_policy != null && !var.fifo_topic ? 1 : 0
+  arn    = aws_sns_topic.this[0].arn
+  policy = var.data_protection_policy
+}

--- a/main.tf
+++ b/main.tf
@@ -160,7 +160,8 @@ resource "aws_sns_topic_subscription" "this" {
 ################################################################################
 
 resource "aws_sns_topic_data_protection_policy" "this" {
-  count  = var.create && var.data_protection_policy != null && !var.fifo_topic ? 1 : 0
+  count = var.create && var.data_protection_policy != null && !var.fifo_topic ? 1 : 0
+
   arn    = aws_sns_topic.this[0].arn
   policy = var.data_protection_policy
 }

--- a/variables.tf
+++ b/variables.tf
@@ -177,3 +177,13 @@ variable "subscriptions" {
   type        = any
   default     = {}
 }
+
+################################################################################
+# Data Protection Policy
+################################################################################
+
+variable "data_protection_policy" {
+  description = "A map of data protection policy statements"
+  type        = string
+  default     = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.56"
+      version = ">= 4.62"
     }
   }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -26,4 +26,5 @@ module "wrapper" {
   topic_policy_statements         = try(each.value.topic_policy_statements, var.defaults.topic_policy_statements, {})
   create_subscription             = try(each.value.create_subscription, var.defaults.create_subscription, true)
   subscriptions                   = try(each.value.subscriptions, var.defaults.subscriptions, {})
+  data_protection_policy          = try(each.value.data_protection_policy, var.defaults.data_protection_policy, null)
 }


### PR DESCRIPTION
## Description
Add data protection policy resource.

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/30008
https://docs.aws.amazon.com/sns/latest/dg/message-data-protection.html

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
