### PR TITLE
feat!: Add `archive_policy` and `replay_policy` configurations and v5 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ module "sns_topic" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.62 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.25 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.25 |
 
 ## Modules
 
@@ -163,6 +163,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_application_feedback"></a> [application\_feedback](#input\_application\_feedback) | Map of IAM role ARNs and sample rate for success and failure feedback | `map(string)` | `{}` | no |
+| <a name="input_archive_policy"></a> [archive\_policy](#input\_archive\_policy) | The message archive policy for FIFO topics. | `string` | `null` | no |
 | <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Boolean indicating whether or not to enable content-based deduplication for FIFO topics. | `bool` | `false` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_subscription"></a> [create\_subscription](#input\_create\_subscription) | Determines whether an SNS subscription is created | `bool` | `true` | no |
@@ -194,6 +195,7 @@ No modules.
 |------|-------------|
 | <a name="output_subscriptions"></a> [subscriptions](#output\_subscriptions) | Map of subscriptions created and their attributes |
 | <a name="output_topic_arn"></a> [topic\_arn](#output\_topic\_arn) | The ARN of the SNS topic, as a more obvious property (clone of id) |
+| <a name="output_topic_beginning_archive_time"></a> [topic\_beginning\_archive\_time](#output\_topic\_beginning\_archive\_time) | The oldest timestamp at which a FIFO topic subscriber can start a replay |
 | <a name="output_topic_id"></a> [topic\_id](#output\_topic\_id) | The ARN of the SNS topic |
 | <a name="output_topic_name"></a> [topic\_name](#output\_topic\_name) | The name of the topic |
 | <a name="output_topic_owner"></a> [topic\_owner](#output\_topic\_owner) | The AWS Account ID of the SNS topic owner |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -23,13 +23,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.25 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.25 |
 
 ## Modules
 
@@ -58,11 +58,13 @@ No inputs.
 |------|-------------|
 | <a name="output_complete_sns_subscriptions"></a> [complete\_sns\_subscriptions](#output\_complete\_sns\_subscriptions) | Map of subscriptions created and their attributes |
 | <a name="output_complete_sns_topic_arn"></a> [complete\_sns\_topic\_arn](#output\_complete\_sns\_topic\_arn) | The ARN of the SNS topic, as a more obvious property (clone of id) |
+| <a name="output_complete_sns_topic_beginning_archive_time"></a> [complete\_sns\_topic\_beginning\_archive\_time](#output\_complete\_sns\_topic\_beginning\_archive\_time) | The oldest timestamp at which a FIFO topic subscriber can start a replay |
 | <a name="output_complete_sns_topic_id"></a> [complete\_sns\_topic\_id](#output\_complete\_sns\_topic\_id) | The ARN of the SNS topic |
 | <a name="output_complete_sns_topic_name"></a> [complete\_sns\_topic\_name](#output\_complete\_sns\_topic\_name) | The name of the topic |
 | <a name="output_complete_sns_topic_owner"></a> [complete\_sns\_topic\_owner](#output\_complete\_sns\_topic\_owner) | The AWS Account ID of the SNS topic owner |
 | <a name="output_default_sns_subscriptions"></a> [default\_sns\_subscriptions](#output\_default\_sns\_subscriptions) | Map of subscriptions created and their attributes |
 | <a name="output_default_sns_topic_arn"></a> [default\_sns\_topic\_arn](#output\_default\_sns\_topic\_arn) | The ARN of the SNS topic, as a more obvious property (clone of id) |
+| <a name="output_default_sns_topic_beginning_archive_time"></a> [default\_sns\_topic\_beginning\_archive\_time](#output\_default\_sns\_topic\_beginning\_archive\_time) | The oldest timestamp at which a FIFO topic subscriber can start a replay |
 | <a name="output_default_sns_topic_id"></a> [default\_sns\_topic\_id](#output\_default\_sns\_topic\_id) | The ARN of the SNS topic |
 | <a name="output_default_sns_topic_name"></a> [default\_sns\_topic\_name](#output\_default\_sns\_topic\_name) | The name of the topic |
 | <a name="output_default_sns_topic_owner"></a> [default\_sns\_topic\_owner](#output\_default\_sns\_topic\_owner) | The AWS Account ID of the SNS topic owner |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -82,6 +82,14 @@ module "complete_sns" {
     }
   })
 
+  # Example config for archive_policy for SNS FIFO message archiving
+  # You can not delete a topic with an active message archive policy
+  # You must first deactivate the topic before it can be deleted
+  # https://docs.aws.amazon.com/sns/latest/dg/message-archiving-and-replay-topic-owner.html
+  # archive_policy = jsonencode({
+  # "MessageRetentionPeriod": 30
+  # })
+
   create_topic_policy         = true
   enable_default_topic_policy = true
   topic_policy_statements = {
@@ -116,6 +124,13 @@ module "complete_sns" {
     sqs = {
       protocol = "sqs"
       endpoint = module.sqs.queue_arn
+
+      # example of replay_policy for SNS FIFO message replay
+      # https://docs.aws.amazon.com/sns/latest/dg/message-archiving-and-replay-subscriber.html
+      # replay_policy = jsonencode({
+      #   "PointType": "Timestamp"
+      #   "StartingPoint": timestamp()
+      # })
     }
   }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -82,12 +82,12 @@ module "complete_sns" {
     }
   })
 
-  # Example config for archive_policy for SNS FIFO message archiving
-  # You can not delete a topic with an active message archive policy
-  # You must first deactivate the topic before it can be deleted
-  # https://docs.aws.amazon.com/sns/latest/dg/message-archiving-and-replay-topic-owner.html
+  # # Example config for archive_policy for SNS FIFO message archiving
+  # # You can not delete a topic with an active message archive policy
+  # # You must first deactivate the topic before it can be deleted
+  # # https://docs.aws.amazon.com/sns/latest/dg/message-archiving-and-replay-topic-owner.html
   # archive_policy = jsonencode({
-  # "MessageRetentionPeriod": 30
+  #   "MessageRetentionPeriod": 30
   # })
 
   create_topic_policy         = true
@@ -125,8 +125,8 @@ module "complete_sns" {
       protocol = "sqs"
       endpoint = module.sqs.queue_arn
 
-      # example of replay_policy for SNS FIFO message replay
-      # https://docs.aws.amazon.com/sns/latest/dg/message-archiving-and-replay-subscriber.html
+      # # example of replay_policy for SNS FIFO message replay
+      # # https://docs.aws.amazon.com/sns/latest/dg/message-archiving-and-replay-subscriber.html
       # replay_policy = jsonencode({
       #   "PointType": "Timestamp"
       #   "StartingPoint": timestamp()

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -22,6 +22,11 @@ output "default_sns_topic_owner" {
   value       = module.default_sns.topic_owner
 }
 
+output "default_sns_topic_beginning_archive_time" {
+  description = "The oldest timestamp at which a FIFO topic subscriber can start a replay"
+  value       = module.default_sns.topic_beginning_archive_time
+}
+
 output "default_sns_subscriptions" {
   description = "Map of subscriptions created and their attributes"
   value       = module.default_sns.subscriptions
@@ -49,6 +54,11 @@ output "complete_sns_topic_name" {
 output "complete_sns_topic_owner" {
   description = "The AWS Account ID of the SNS topic owner"
   value       = module.complete_sns.topic_owner
+}
+
+output "complete_sns_topic_beginning_archive_time" {
+  description = "The oldest timestamp at which a FIFO topic subscriber can start a replay"
+  value       = module.complete_sns.topic_beginning_archive_time
 }
 
 output "complete_sns_subscriptions" {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.40"
+      version = ">= 5.25"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,8 @@ resource "aws_sns_topic" "this" {
   sqs_success_feedback_role_arn    = try(var.sqs_feedback.success_role_arn, null)
   sqs_success_feedback_sample_rate = try(var.sqs_feedback.success_sample_rate, null)
 
+  archive_policy = try(var.archive_policy, null)
+
   tags = var.tags
 }
 
@@ -151,6 +153,7 @@ resource "aws_sns_topic_subscription" "this" {
   protocol                        = each.value.protocol
   raw_message_delivery            = try(each.value.raw_message_delivery, null)
   redrive_policy                  = try(each.value.redrive_policy, null)
+  replay_policy                   = try(each.value.replay_policy, null)
   subscription_role_arn           = try(each.value.subscription_role_arn, null)
   topic_arn                       = aws_sns_topic.this[0].arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,6 +22,11 @@ output "topic_owner" {
   value       = try(aws_sns_topic.this[0].owner, null)
 }
 
+output "topic_beginning_archive_time" {
+  description = "The oldest timestamp at which a FIFO topic subscriber can start a replay"
+  value       = try(aws_sns_topic.this[0].beginning_archive_time, null)
+}
+
 ################################################################################
 # Subscription(s)
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,12 @@ variable "tracing_config" {
   default     = null
 }
 
+variable "archive_policy" {
+  description = "The message archive policy for FIFO topics."
+  type        = string
+  default     = null
+}
+
 ################################################################################
 # Topic Policy
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.62"
+      version = ">= 5.25"
     }
   }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -20,6 +20,7 @@ module "wrapper" {
   sqs_feedback                    = try(each.value.sqs_feedback, var.defaults.sqs_feedback, {})
   signature_version               = try(each.value.signature_version, var.defaults.signature_version, null)
   tracing_config                  = try(each.value.tracing_config, var.defaults.tracing_config, null)
+  archive_policy                  = try(each.value.archive_policy, var.defaults.archive_policy, null)
   create_topic_policy             = try(each.value.create_topic_policy, var.defaults.create_topic_policy, true)
   source_topic_policy_documents   = try(each.value.source_topic_policy_documents, var.defaults.source_topic_policy_documents, [])
   override_topic_policy_documents = try(each.value.override_topic_policy_documents, var.defaults.override_topic_policy_documents, [])


### PR DESCRIPTION
## Description
https://github.com/hashicorp/terraform-provider-aws/issues/34150

## Motivation and Context
https://aws.amazon.com/about-aws/whats-new/2023/10/amazon-sns-in-place-message-archiving-replay-fifo-topics/

## Breaking Changes
Yes aws provider v5 upgrade.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
