### PR TITLE
docs: Fix incorrect `condition` key in SQS example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -220,11 +220,13 @@ module "sqs" {
         }
       ]
 
-      condition = {
-        test     = "ArnEquals"
-        variable = "aws:SourceArn"
-        values   = [module.complete_sns.topic_arn]
-      }
+      conditions = [
+        {
+          test     = "ArnEquals"
+          variable = "aws:SourceArn"
+          values   = [module.complete_sns.topic_arn]
+        }
+      ]
     }
   }
 


### PR DESCRIPTION
## Description
The `condition` key in the SQS example is incorrect and should be replaced with a `conditions` key that takes an array of objects (see https://github.com/terraform-aws-modules/terraform-aws-sqs/blob/75e57f71c2c9a2ffb0c17b8e67d7151e345a343f/main.tf#L70).

## Motivation and Context
When referring to the example, new users to the module will not run into issues.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request