### PR TITLE
feat: Automatically append .fifo to fifo topic names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,11 +4,15 @@ data "aws_caller_identity" "current" {}
 # Topic
 ################################################################################
 
+locals {
+  name = try(trimsuffix(var.name, ".fifo"), "")
+}
+
 resource "aws_sns_topic" "this" {
   count = var.create ? 1 : 0
 
-  name        = var.use_name_prefix ? null : var.name
-  name_prefix = var.use_name_prefix ? var.name : null
+  name        = var.use_name_prefix ? null : (var.fifo_topic ? "${local.name}.fifo" : local.name)
+  name_prefix = var.use_name_prefix ? "${local.name}-" : null
 
   application_failure_feedback_role_arn    = try(var.application_feedback.failure_role_arn, null)
   application_success_feedback_role_arn    = try(var.application_feedback.success_role_arn, null)


### PR DESCRIPTION
## Description
With this change, we automatically append the .fifo suffix to fifo topic names since it is required by AWS SNS. We also sanitise the name input to ensure that if users have already included the .fifo suffix in their topic names it will not be appended again.

## Motivation and Context
- Resolves #54 

## Breaking Changes
-

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
