### PR TITLE
fix: SID must only include alphanumeric characters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "this" {
     for_each = var.enable_default_topic_policy ? [1] : []
 
     content {
-      sid = "__default_statement_ID"
+      sid = "DefaultStatementID"
       actions = [
         "sns:Subscribe",
         "sns:SetTopicAttributes",


### PR DESCRIPTION
## Description
Fix [this](https://github.com/terraform-aws-modules/terraform-aws-sns/issues/59) bug 

## Motivation and Context
(https://github.com/terraform-aws-modules/terraform-aws-sns/issues/59)

## Breaking Changes
No

## How Has This Been Tested?
I ran a `terraform plan `with this forked version and plan came clear. Using latest version I get:

```
│ Error: invalid value for statement.0.sid (must only include alphanumeric characters)
│ 
│   with module.terraform-aws-sns.data.aws_iam_policy_document.this[0],
│   on .terraform/modules/terraform-aws-sns/main.tf line 51, in data "aws_iam_policy_document" "this":
│   51: data "aws_iam_policy_document" "this" {

```