### PR TITLE
fix: Change default policy from deprecated `SourceOwner` to `SourceAccount`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.1
+    rev: v1.98.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "this" {
       condition {
         test     = "StringEquals"
         values   = [data.aws_caller_identity.current.account_id]
-        variable = "AWS:SourceOwner"
+        variable = "AWS:SourceAccount"
       }
     }
   }


### PR DESCRIPTION
## Description
- Change default policy from deprecated `SourceOwner` to `SourceAccount`

## Motivation and Context
- Resolves #56

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
