### PR TITLE
docs: Fix topic_policy_statements example key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module "sns_topic" {
         identifiers = ["*"]
       }]
 
-      conditions = [{
+      condition = [{
         test     = "StringLike"
         variable = "sns:Endpoint"
         values   = ["arn:aws:sqs:eu-west-1:11111111111:subscriber"]
@@ -103,7 +103,7 @@ module "sns_topic" {
         identifiers = ["*"]
       }]
 
-      conditions = [{
+      condition = [{
         test     = "StringLike"
         variable = "sns:Endpoint"
         values   = ["arn:aws:sqs:eu-west-1:11111111111:subscriber.fifo"]


### PR DESCRIPTION
## Summary
- Update README examples for `topic_policy_statements` to use `condition` instead of `conditions`
- Align docs with the schema change introduced in `f9269fba`
- Keep SQS policy examples unchanged (they still correctly use `conditions`)

## Test plan
- [x] Searched docs for `conditions = [` occurrences
- [x] Verified README now uses `condition = [` in both topic policy examples
- [x] Confirmed only non-doc/example SQS usage remains where applicable

Made with [Cursor](https://cursor.com)